### PR TITLE
Remove redundant logging guidelines

### DIFF
--- a/project_and_code_guidelines.md
+++ b/project_and_code_guidelines.md
@@ -271,33 +271,7 @@ More info [here](https://source.android.com/source/code-style.html#limit-variabl
 
 ### 2.2.9 Logging guidelines
 
-Use the logging methods provided by the `Log` class to print out error messages or other information that may be useful for developers to identify issues:
-
-* `Log.v(String tag, String msg)` (verbose)
-* `Log.d(String tag, String msg)` (debug)
-* `Log.i(String tag, String msg)` (information)
-* `Log.w(String tag, String msg)` (warning)
-* `Log.e(String tag, String msg)` (error)
-
-As a general rule, we use the class name as tag and we define it as a `static final` field at the top of the file. For example:
-
-```java
-public class MyClass {
-    private static final String TAG = MyClass.class.getSimpleName();
-
-    public myMethod() {
-        Log.e(TAG, "My error message");
-    }
-}
-```
-
 VERBOSE and DEBUG logs __must__ be disabled on release builds. It is also recommended to disable INFORMATION, WARNING and ERROR logs but you may want to keep them enabled if you think they may be useful to identify issues on release builds. If you decide to leave them enabled, you have to make sure that they are not leaking private information such as email addresses, user ids, etc.
-
-To only show logs on debug builds:
-
-```java
-if (BuildConfig.DEBUG) Log.d(TAG, "The value of x is " + x);
-```
 
 ### 2.2.10 Class member ordering
 


### PR DESCRIPTION
In our project we use our own Log class for logging so the examples of android.util.Log could be misleading although it's not prohibited to use it. 
I think logging is pretty much straight forward and basic guidelines is enough.