### PR TITLE
Remove link to icon naming source. Add layout file naming case

### DIFF
--- a/project_and_code_guidelines.md
+++ b/project_and_code_guidelines.md
@@ -31,8 +31,6 @@ Naming conventions for drawables:
 | Notification | `notification_`	| `notification_bg.9.png`     |
 | Tabs         | `tab_`            | `tab_pressed.9.png`         |
 
-Naming conventions for icons (taken from [Android iconography guidelines](http://developer.android.com/design/style/iconography.html)):
-
 | Asset Type                      | Prefix             | Example                      |
 | --------------------------------| ----------------   | ---------------------------- |
 | Icons                           | `ic_`              | `ic_star.png`                |
@@ -63,9 +61,12 @@ Layout files should match the name of the Android components that they are inten
 | Fragment         | `SignUpFragment`       | `fragment_sign_up.xml`        |
 | Dialog           | `ChangePasswordDialog` | `dialog_change_password.xml`  |
 | AdapterView item | ---                    | `item_person.xml`             |
+| View / ViewGroup | `SliderView`           | `view_slider.xml`             |
 | Partial layout   | ---                    | `partial_stats_bar.xml`       |
 
 A slightly different case is when we are creating a layout that is going to be inflated by an `Adapter`, e.g to populate a `ListView`. In this case, the name of the layout should start with `item_`.
+
+Other case is when layout is intended to be inflated as View or ViewGroup custom implementation layout. In this case `view_` prefix should be used.
 
 Note that there are cases where these rules will not be possible to apply. For example, when creating layout files that are intended to be part of other layouts. In this case you should use the prefix `partial_`.
 


### PR DESCRIPTION
Removed the link to Android iconography guidelines as it is not useful in these guidelines.

Added additional case for layout file naming when file is intended to be used for View or ViewGroup custom implementation. We have several this type of usages in our project.